### PR TITLE
Allow simple include of lvgl.h header

### DIFF
--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -195,7 +195,11 @@ class Converter {
 
     get_c_header(out_name: string): string {
         var $c_header =
-        `#include \"lvgl/lvgl.h\"
+        `#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include \"lvgl.h\"
+#else
+#include \"lvgl/lvgl.h\"
+#endif
 
 #ifndef LV_ATTRIBUTE_MEM_ALIGN
 #define LV_ATTRIBUTE_MEM_ALIGN


### PR DESCRIPTION
Allow users to use the simple include of lvgl.h in case LV_LVGL_H_INCLUDE_SIMPLE is defined. lv_font_conv already does this [here](https://github.com/lvgl/lv_font_conv/blob/4677fed860332139df94a7f7f566ce3854cc563d/lib/writers/lvgl/lv_font.js#L69).