### PR TITLE
Update Dockerfile to prevent failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM node:14
+FROM ubuntu:20.04
 
 ENV PATH=/usr/src/app:$PATH
 
 RUN mkdir -p /usr/src/app
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+RUN apt install -y gcc make g++ pkg-config libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg8-dev libgif-dev nodejs npm imagemagick
+RUN npm install -g ts-node
 COPY . /usr/src/app
-RUN cd /usr/src/app && npm install typescript
+RUN cd /usr/src/app && npm install
 
 VOLUME /usr/src/proj
 
 WORKDIR /usr/src/proj
 
 ENTRYPOINT ["entrypoint.sh"]
-


### PR DESCRIPTION
The contents of this PR were taken directly from https://github.com/lvgl/lv_img_conv/issues/37#issuecomment-2090450513 

This should prevent getting the `Failed to deserialize buffer as swc::config::Options` when attempting to run the tool through docker.